### PR TITLE
Remove Python 3.5 from Actions test matrix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Remove Python 3.5 from Actions strategy matrix of environment options.  

I see a few conflicting things in different places, but according to [this page](https://www.python.org/downloads/release/python-3510/), 3.5 is going to be end-of-life by the end of September. 

Given that, I think it makes sense to not have the project support that Python version.

