### PR TITLE
Initial Support for Local Linting

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f python/requirements.txt ]; then pip install -r python/requirements.txt; fi
     - name: Lint with flake8

--- a/README.md
+++ b/README.md
@@ -34,7 +34,15 @@ source ./venv/bin/activate
 pip install -r python/requirements.txt
 ```
 Then use `pytest` to run the tests:
+
 `pytest --log-cli-level 0 python/hypy/test/`
+
+Also, the following check commands can be run locally to perform code analysis.  PRs have these or similar checks run automatically (see the Github Actions [config file](.github/workflows/python-package.yml)).
+
+```
+flake8 ./python --count --select=E9,F63,F7,F82 --show-source --statistics
+flake8 ./python --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+```
 
 ## Known issues
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,3 @@
 pytest
+flake8
 pandas

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,13 @@ try:
 except:
     long_description = 'HY_Features python package.'
 
-exec(open('hypy/_version.py').read())
+# Set __version__ to prevent analysis check issues, but later make sure it gets read properly
+__version__ = ''
+_version_file = 'hypy/_version.py'
+exec(open(_version_file).read())
+# Raise error if __version__ is still the pre-set empty string
+if __version__ == '':
+    raise RuntimeError('Failed to read package "__version__" from package version file "{}".'.format(_version_file))
 
 setup(
     name='hypy',


### PR DESCRIPTION
Updating project config and docs for facilitating linting checks locally in dev environments.
## Changes

- Add `flake8` to project Python _requirements.txt_
- Adjust explicit, separate install of `flake8` in Github Action, since now install by _requirements.txt_
- Update readme with info on running check commands
- Adjusted _setup.py_ so it does not trigger an error during checks for something known to not actually be a problem

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist
