### PR TITLE
Initial Formulation classes

### DIFF
--- a/python/hypy/__init__.py
+++ b/python/hypy/__init__.py
@@ -1,4 +1,4 @@
 from .nexus import Nexus, Observation_Point
 from .realization import Realization
-from .formulation import Formulation
-from .catchment import Catchment
+from .formulation import CatchmentFormulation, Formulation
+from .catchment import Catchment, FormulatableCatchment

--- a/python/hypy/catchment.py
+++ b/python/hypy/catchment.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from .formulation import Formulation
+from .formulation import CatchmentFormulation
 from .nexus import Nexus
 from .realization import Realization
 from typing import List, Optional, Tuple, Union
@@ -238,7 +238,7 @@ class FormulatableCatchment(Catchment):
                  contained_catchments: Catchments_Collection = tuple(),
                  containing_catchment: Optional['Catchment'] = None,
                  conjoined_catchments: Catchments_Collection = tuple(),
-                 formulation: Optional[Formulation] = None,
+                 formulation: Optional[CatchmentFormulation] = None,
                  realization: Optional[Realization] = None):
         """
         Set the catchment identity and transform the raw params into dataframes.
@@ -259,7 +259,7 @@ class FormulatableCatchment(Catchment):
             An optional catchment that contains this one.
         conjoined_catchments: Catchments_Collection
             A collection of conjoined catchments related to this catchment.
-        formulation: Optional[Formulation]
+        formulation: Optional[CatchmentFormulation]
             The optional modeling formulation object associated with this catchment.
         realization: Optional[Realization]
             The optional catchment realization object associated with this catchment.
@@ -272,19 +272,19 @@ class FormulatableCatchment(Catchment):
             self._formulation.catchment = self
 
     @property
-    def formulation(self) -> Optional[Formulation]:
+    def formulation(self) -> Optional[CatchmentFormulation]:
         """
-        The optional ::class:`Formulation` for this catchment.
+        The optional ::class:`CatchmentFormulation` for this catchment.
 
         Returns
         -------
-        Optional[Formulation]
-            The ::class:`Formulation` for this catchment, or ``None`` if it has not been set.
+        Optional[CatchmentFormulation]
+            The ::class:`CatchmentFormulation` for this catchment, or ``None`` if it has not been set.
         """
         return self._formulation
 
     @formulation.setter
-    def formulation(self, formulation: Formulation):
+    def formulation(self, formulation: CatchmentFormulation):
         self._formulation = formulation
 
 

--- a/python/hypy/formulation.py
+++ b/python/hypy/formulation.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Type, TYPE_CHECKING
 
+if TYPE_CHECKING:
+    from .catchment import FormulatableCatchment
 
 
 class Formulation(ABC):
@@ -110,3 +112,25 @@ class Formulation(ABC):
         ::method:`get_required_params_for_type`
         """
         pass
+
+
+class CatchmentFormulation(Formulation, ABC):
+    """
+    An abstract extension specifically representing a formulatable catchment's formulation.
+    """
+
+    __slots__ = ['_catchment']
+
+    def __init__(self, formulation_id: str, catchment: Optional['FormulatableCatchment']):
+        super().__init__(formulation_id=formulation_id)
+        self._catchment = catchment
+        if self._catchment is not None:
+            self._catchment.formulation = self
+
+    @property
+    def catchment(self) -> Optional['FormulatableCatchment']:
+        return self._catchment
+
+    @catchment.setter
+    def catchment(self, catchment: 'FormulatableCatchment'):
+        self._catchment = catchment

--- a/python/hypy/formulation.py
+++ b/python/hypy/formulation.py
@@ -1,23 +1,112 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Optional, Type, TYPE_CHECKING
 
 
-class Formulation(object):
+
+class Formulation(ABC):
     """
 
     """
     __slots__ = ['_id']
-    def __init__(self, id):
-        """
 
+    @classmethod
+    @abstractmethod
+    def factory_create_from_config(cls, local_config: dict, global_config: Optional[dict] = None) -> 'Formulation':
         """
-        self._id = id
+        Factory create a new instance from the provide local and (optional) global config.
 
-    @property
-    def id(self) -> str:
-        """Return formulation identifier
+        Parameters
+        ----------
+        local_config
+        global_config
 
         Returns
         -------
-            str
-                formulation identifier
+        Formulation
+            A new formulation object.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def get_formulation_type(cls) -> str:
+        """
+        Get the name of this formulation type that will represent it in serialized configurations to indicate the type
+        of formulation to be used.
+
+        Returns
+        -------
+        str
+            The name of this formulation type that will represent it in serialized configurations.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def get_required_params_for_type(cls) -> Dict[str, Type]:
+        """
+        Get the names of all the required parameters for this formulation type as a dictionary, where the mapped values
+        are the acceptable type(s) for each formulation parameter, when these can be universally defined for all
+        instances of this particular type (i.e., not subclasses).
+
+        However, all implementations of this type should hold to the invariant that at least one of the following is
+        always ``True``:
+            - ``self.get_required_params_for_type() == self.required_params()``
+            - ``len(self.get_required_params_for_type()) == 0``
+
+        That is, types should ensure the instance and class methods return the equivalent values unless it is not
+        possible to define required parameters on the class level, in which case this method should return an empty
+        dictionary.
+
+        Returns
+        -------
+        Dict[str, Type]
+            A map of required formulation params to each's expected type(s), applicable to all instances of this type.
+
+        See Also
+        -------
+        ::method:`required_params`
+        """
+        pass
+
+    def __init__(self, formulation_id: str):
+        self._id = formulation_id
+
+    @property
+    def id(self) -> str:
+        """
+        The formulation identifier.
+
+        Returns
+        -------
+        str
+            The formulation identifier.
         """
         return self._id
+
+    @abstractmethod
+    def get_response(self, input_flux: float, **kwargs) -> float:
+        pass
+
+    @property
+    @abstractmethod
+    def required_params(self) -> Dict[str, Type]:
+        """
+        Get the names of all the required parameters for this formulation as a dictionary, where the mapped values are
+        the acceptable type(s) for each formulation parameter.
+
+        However, all implementations of this type should hold to the invariant that at least one of the following is
+        always ``True``:
+            - ``self.get_required_params_for_type() == self.required_params()``
+            - ``len(self.get_required_params_for_type()) == 0``
+
+        Returns
+        -------
+        Dict[str, Type]
+            A map of required formulation parameters to each's expected type(s).
+
+        See Also
+        -------
+        ::method:`get_required_params_for_type`
+        """
+        pass

--- a/python/hypy/test/test_formulation.py
+++ b/python/hypy/test/test_formulation.py
@@ -1,18 +1,126 @@
+import json
 import pytest
+from pathlib import Path
+from typing import Optional, Dict, Type
 
-from hypy import Formulation
+from hypy import CatchmentFormulation, FormulatableCatchment
+
+
+# Need subtype that is not abstract
+class CatchmentFormulationTestImpl(CatchmentFormulation):
+
+    __slots__ = ['_maxsmc']
+
+    @classmethod
+    def factory_create_from_config(cls, local_config: dict, global_config: Optional[dict] = None) -> 'CatchmentFormulationTestImpl':
+        # Leave this alone actually
+        pass
+
+    @classmethod
+    def get_formulation_type(cls) -> str:
+        return cls.__name__
+
+    @classmethod
+    def get_required_params_for_type(cls) -> Dict[str, Type]:
+        return {'maxsmc': float}
+
+    def __init__(self, formulation_id: str, catchment: Optional[FormulatableCatchment], catchment_id: Optional[str] = None):
+        super().__init__(formulation_id=formulation_id, catchment=catchment)
+        if catchment_id is not None and self.catchment is None:
+            self._catchment_id = catchment_id
+
+    @property
+    def catchment_id(self) -> str:
+        return self.catchment.id if self.catchment is not None else self._catchment_id
+
+    def get_response(self, input_flux: float, **kwargs) -> float:
+        return 0.0
+
+    @property
+    def required_params(self) -> Dict[str, Type]:
+        return self.get_required_params_for_type()
+
+
+_current_dir = Path(__file__).resolve().parent
+
 
 @pytest.fixture
-def formulation():
+def formulation_1():
     """
-        Nexus object to test
     """
-    id = 'cat-test'
-    formulation = Formulation(id)
+    id = 'form-test-1'
+
+    data_path = _current_dir.joinpath('data')
+    data_file = data_path.joinpath('example_realization_config.json')
+    with open(data_file) as fp:
+        data = json.load(fp)
+    forcing_path = Path(data['catchments']['cat-88']['forcing']['path'])
+    forcing_path = data_path.joinpath('forcing').joinpath(forcing_path.name)
+
+    catchment_params = {'forcing': {'path': forcing_path}}
+
+    formulation = CatchmentFormulationTestImpl(id, catchment=None)
+    catchment = FormulatableCatchment('cat-test', catchment_params, formulation=formulation)
     yield formulation
 
-def test_formulation(formulation):
+
+@pytest.fixture
+def formulation_2():
     """
-        Test proper construction of formulation
     """
-    assert formulation.id == 'cat-test'
+    id = 'form-test-2'
+
+    data_path = _current_dir.joinpath('data')
+    data_file = data_path.joinpath('example_realization_config.json')
+    with open(data_file) as fp:
+        data = json.load(fp)
+    forcing_path = Path(data['catchments']['cat-88']['forcing']['path'])
+    forcing_path = data_path.joinpath('forcing').joinpath(forcing_path.name)
+
+    catchment_params = {'forcing': {'path': forcing_path}}
+
+    catchment = FormulatableCatchment('cat-test-2', catchment_params)
+    formulation = CatchmentFormulationTestImpl(id, catchment=catchment)
+    yield formulation
+
+
+def test_formulation_1_a(formulation_1):
+    """
+    Test proper construction of formulation.
+    """
+    assert formulation_1.id == 'form-test-1'
+
+
+def test_formulation_1_b(formulation_1):
+    """
+    Test formulation is associated with catchment
+    """
+    assert formulation_1.catchment is not None
+
+
+def test_formulation_1_c(formulation_1):
+    """
+    Test formulation is associated with catchment that is associated with this catchment.
+    """
+    assert formulation_1.catchment.formulation.id == 'form-test-1'
+
+
+def test_formulation_2_a(formulation_2):
+    """
+    Test proper construction of formulation.
+    """
+    assert formulation_2.id == 'form-test-2'
+
+
+def test_formulation_2_b(formulation_2):
+    """
+    Test formulation is associated with catchment
+    """
+    assert formulation_2.catchment is not None
+
+
+def test_formulation_2_c(formulation_2):
+    """
+    Test formulation is associated with catchment that is associated with this catchment.
+    """
+    assert formulation_2.catchment.formulation.id == 'form-test-2'


### PR DESCRIPTION
Adding initial formulation interface classes - one base, and one specifically applicable to catchments - and integration with catchments.  

## Additions

- a more complete abstract base interface class, along with several abstract method declarations for things expected to be necessary for the interface
- a catchment-specific abstract subtype
    - this was created since it wasn't immediately clear to me whether it was possible to have formulations in other contexts
    - it can be rolled up into the base if it is superfluous
- per discussion,  new _FormulatableCatchment_  extension of _Catchment_

## Removals

-

## Changes

- _Catchment_ references to formulations have been moved to the _FormulatableCatchment_ class
    - this keeps the base class from having something (i.e., the _formulation_ property) outside the _HY Features_ spec

## Testing

- Several simple unit tests have been added that test object initialization and association with a catchment.

## Screenshots


## Notes

- A concrete example (say, of Tshirt) could also be added if deemed necessary, before merging these changes in.

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist
