### PR TITLE
Account for dependency name change

### DIFF
--- a/python/hypy/hydrolocation/nwis_location.py
+++ b/python/hypy/hydrolocation/nwis_location.py
@@ -1,5 +1,5 @@
 from typing import Union, Tuple, TYPE_CHECKING
-from evaluation_tools import nwis_client
+from hydrotools import nwis_client
 
 from hypy.hydrolocation import HydroLocation, HydroLocationType
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 pytest
 flake8
 pandas
-git+https://github.com/noaa-owp/evaluation_tools@master#egg=evaluation-tools-nwis_client&subdirectory=python/nwis_client
-git+https://github.com/noaa-owp/evaluation_tools@master#egg=evaluation-tools-_restclientt&subdirectory=python/_restclient
+git+https://github.com/noaa-owp/hydrotools#egg=hydrotools-nwis_client&subdirectory=python/nwis_client
+git+https://github.com/noaa-owp/hydrotools#egg=hydrotools-_restclientt&subdirectory=python/_restclient


### PR DESCRIPTION
Adjust requirements file and code module imports to account for the renaming of the OWP _evaluation_tools_ repository/namespace to [_hydrotools_](https://github.com/NOAA-OWP/hydrotools).

In particular, this uses the contained _nwis_client_ and _\_restclient_ packages.
