### PR TITLE
`git+git://` URLs don't work anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Unit testing done with [pytest](https://github.com/pytest-dev/pytest).  See [req
 
 ## Installation
 Package can be installed from source using pip:
-`pip install -e "git+git://github.com/noaa-owp/hypy@master#egg=hypy&subdirectory=python"`
+`pip install -e "git+https://github.com/noaa-owp/hypy@master#egg=hypy&subdirectory=python"`
 
 `TODO` see [INSTALL](INSTALL.md).
 


### PR DESCRIPTION
`git+git://` URLs don't work anymore I don't think?

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist
