### PR TITLE
bump  actions/setup-python@v2 to @v4

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
Github actions were using an old version of [`actions/setup-python`](https://github.com/actions/setup-python), `@v2`, this bumps that version to the current version `@v4`.