### PR TITLE
refactor / style: Type hint and style improvements

### DIFF
--- a/python/hypy/hydrolocation/hydrolocation.py
+++ b/python/hypy/hydrolocation/hydrolocation.py
@@ -76,7 +76,7 @@ class HydroLocation:
     @property
     def geometry(self) -> Point | tuple[float, float]:
         """
-            Geometric coordinates of the location as a `Point` or two-Tuple
+        Geodetic coordinates of the location as a `Point` or tuple of two floats
         """
         return self._shape
 

--- a/python/hypy/hydrolocation/hydrolocation.py
+++ b/python/hypy/hydrolocation/hydrolocation.py
@@ -74,7 +74,7 @@ class HydroLocation:
         return self._realized_nexus
 
     @property
-    def geometry(self) -> Point | Tuple:
+    def geometry(self) -> Point | tuple[float, float]:
         """
             Geometric coordinates of the location as a `Point` or two-Tuple
         """

--- a/python/hypy/hydrolocation/nwis_location.py
+++ b/python/hypy/hydrolocation/nwis_location.py
@@ -10,10 +10,13 @@ if TYPE_CHECKING:
     from numpy import datetime64
     from datetime import datetime
     from shapely.geometry import Point
+
 class NWISLocation(HydroLocation):
     """
     An NWIS subclass of HydroLocation
     """
+    __slots__ = ("_station_id",)
+
     def __init__(self,
                 station_id: str,
                 realized_nexus: str,

--- a/python/hypy/hydrolocation/nwis_location.py
+++ b/python/hypy/hydrolocation/nwis_location.py
@@ -1,4 +1,6 @@
-from typing import Union, Tuple, TYPE_CHECKING
+from __future__ import annotations
+
+from typing import Tuple, TYPE_CHECKING
 from hydrotools import nwis_client
 
 from hypy.hydrolocation import HydroLocation, HydroLocationType
@@ -15,7 +17,7 @@ class NWISLocation(HydroLocation):
     def __init__(self,
                 station_id: str,
                 realized_nexus: str,
-                shape: Union['Point', Tuple] = None,
+                shape: Point | Tuple = None,
                 referenced_position = None, #TODO implement indirect position?
                 ):
         """
@@ -42,9 +44,9 @@ class NWISLocation(HydroLocation):
         return self._station_id
 
     def get_data(self,
-                 start: Union[ str, 'datetime', 'datetime64', 'Timestamp', None ] = None,
-                 end: Union[ str, 'datetime', 'datetime64', 'Timestamp', None ] = None
-                 ) -> 'DataFrame':
+                 start: str | datetime | datetime64 | Timestamp | None = None,
+                 end: str | datetime | datetime64 | Timestamp | None = None
+                 ) -> DataFrame:
         """
             Get observation data from nwis
         """

--- a/python/hypy/hydrolocation/nwis_location.py
+++ b/python/hypy/hydrolocation/nwis_location.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from shapely.geometry import Point
 class NWISLocation(HydroLocation):
     """
-        An NWIS subclass of HydroLocation
+    An NWIS subclass of HydroLocation
     """
     def __init__(self,
                 station_id: str,
@@ -24,7 +24,7 @@ class NWISLocation(HydroLocation):
 
         Parameters
         ----------
-        shape: Union[Point, Tuple]
+        shape: Point | Tuple
             a shapely point geometry or two-tuple defining the coordinates of this location
         station_id: str
             NWIS station identifier 
@@ -35,11 +35,11 @@ class NWISLocation(HydroLocation):
         """
         super().__init__(realized_nexus, shape, HydroLocationType.hydrometricStation, referenced_position)
         self._station_id = station_id
-        #self._nwis = nwis_client.IVDataService()
+
     @property
     def station_id(self) -> str:
         """
-            NWIS station identifier
+        NWIS station identifier
         """
         return self._station_id
 
@@ -48,6 +48,6 @@ class NWISLocation(HydroLocation):
                  end: str | datetime | datetime64 | Timestamp | None = None
                  ) -> DataFrame:
         """
-            Get observation data from nwis
+        Get observation data from NWIS
         """
         return nwis_client.IVDataService().get(self._station_id, startDT=start, endDT=end)

--- a/python/hypy/nexus.py
+++ b/python/hypy/nexus.py
@@ -7,32 +7,7 @@ class Nexus():
     """
     Implementation of the HY Features Nexus concept.
     """
-
-    @classmethod
-    def _convert_collection_to_tuple(cls, collection: 'Catchments_Collection') -> Tuple['Catchment', ...]:
-        """
-        Convenience method to accept a ``Catchments_Collection``, which is a union of several possible types, and to
-        output a tuple of catchments (or an empty tuple).
-        Parameters
-        ----------
-        collection: Catchments_Collection
-            A collection of catchment objects, which could be objects within certain containers, an empty container, or
-            a single catchment object itself.
-        Returns
-        -------
-        Tuple['Catchment', ...]
-            A tuple containing the catchments included directly or in the container parameter object.
-        """
-        if isinstance(collection, list):
-            return tuple(collection)
-        elif isinstance(collection, tuple):
-            return collection
-        # Assuming type hinting is followed, the only thing this should leave is the single catchment
-        # TODO: consider whether any cases outside of type hint need to be addressed
-        else:
-            return (collection,)
-
-    __slots__ = ["_id", "_receiving_catchments", "_contributing_catchments", "_hydro_location"]
+    __slots__ = ("_id", "_receiving_catchments", "_contributing_catchments", "_hydro_location")
 
     def __init__(self, 
                  nexus_id: str, 
@@ -89,3 +64,29 @@ class Nexus():
             Tuple of Catchment object(s) contributing water to nexus
         """
         return self._contributing_catchments 
+
+    @staticmethod
+    def _convert_collection_to_tuple(collection: Catchments_Collection) -> tuple[Catchment, ...]:
+        """
+        Convenience method to accept a ``Catchments_Collection``, which is a union of several possible types, and to
+        output a tuple of catchments (or an empty tuple).
+        Parameters
+        ----------
+        collection: Catchments_Collection
+            A collection of catchment objects, which could be objects within certain containers, an empty container, or
+            a single catchment object itself.
+        Returns
+        -------
+        tuple[Catchment, ...]
+            A tuple containing the catchments included directly or in the container parameter object.
+        """
+        # avoid circular import
+        from .catchment import Catchment
+        if isinstance(collection, list):
+            return tuple(collection)
+        elif isinstance(collection, tuple):
+            return collection
+        elif isinstance(collection, Catchment):
+            return (collection,)
+        else:
+            raise AssertionError("unreachable")

--- a/python/hypy/nexus.py
+++ b/python/hypy/nexus.py
@@ -24,6 +24,8 @@ class Nexus():
         ----------
         nexus_id: str
             The identifier string for this nexus
+        hydro_location: HydroLocation
+            HydroLocation associated with this nexus
         receiving_catchments: Catchments_Collection
             The catchment object(s) that receive(s) water from this nexus
         contributing_catchments: Catchments_Collection
@@ -52,7 +54,7 @@ class Nexus():
 
         Returns
         -------
-        Tuple['Catchment', ...]
+        tuple[Catchment, ...]
             Tuple of Catchment object(s) receiving water from nexus 
         """
         return self._receiving_catchments 
@@ -63,7 +65,7 @@ class Nexus():
 
         Returns
         -------
-        Tuple['Catchment', ...]
+        tuple[Catchment, ...]
             Tuple of Catchment object(s) contributing water to nexus
         """
         return self._contributing_catchments 

--- a/python/hypy/nexus.py
+++ b/python/hypy/nexus.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from .catchment import Catchment, Catchments_Collection
     from .hydrolocation.hydrolocation import HydroLocation
 
-class Nexus():
+class Nexus:
     """
     Implementation of the HY Features Nexus concept.
     """

--- a/python/hypy/nexus.py
+++ b/python/hypy/nexus.py
@@ -1,7 +1,10 @@
-from typing import List, Optional, Tuple, TYPE_CHECKING, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .catchment import Catchment, Catchments_Collection
+    from .hydrolocation.hydrolocation import HydroLocation
 
 class Nexus():
     """
@@ -11,9 +14,9 @@ class Nexus():
 
     def __init__(self, 
                  nexus_id: str, 
-                 hydro_location,
-                 receiving_catchments: 'Catchments_Collection' = tuple(),
-                 contributing_catchments: 'Catchments_Collection' = tuple()):   
+                 hydro_location: HydroLocation,
+                 receiving_catchments: Catchments_Collection = tuple(),
+                 contributing_catchments: Catchments_Collection = tuple()):
         """
         Set the nexus identity and params
         
@@ -44,7 +47,7 @@ class Nexus():
         return self._id
 
     @property
-    def receiving_catchments (self) -> Tuple['Catchment', ...]:
+    def receiving_catchments (self) -> tuple[Catchment, ...]:
         """Tuple of Catchment object(s) receiving water from nexus
 
         Returns
@@ -55,7 +58,7 @@ class Nexus():
         return self._receiving_catchments 
 
     @property
-    def contributing_catchments (self) -> Tuple['Catchment', ...]:
+    def contributing_catchments (self) -> tuple[Catchment, ...]:
         """Tuple of Catchment object(s) contributing water to nexus
 
         Returns


### PR DESCRIPTION
Closes #34

Improve type hints style in a few places.

`Nexus._convert_collection_to_tuple` is only thing that functionally changed.
If you weren't following the type hints you may now get an `AssertionError("unreachable")` but IMO the API has not changed so this is not a breaking change.
Likewise, it is ow a `staticmethod` instead of a `classmethod`.
